### PR TITLE
Add a couple more C++ tests and expose setBondStereoFromDirections() to Python

### DIFF
--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -868,6 +868,17 @@ struct molops_wrapper {
                 (python::arg("mol"), python::arg("confId") = -1),
                 docString.c_str());
 
+    docString =
+        "Uses the directions of neighboring bonds to set cis/trans stereo on double bonds.\n\
+        \n\
+  ARGUMENTS:\n\
+  \n\
+    - mol: the molecule to be modified\n\
+\n";
+    python::def("SetBondStereoFromDirections", MolOps::setBondStereoFromDirections,
+                (python::arg("mol")),
+                docString.c_str());
+
     // ------------------------------------------------------------------------
     docString =
         "Kekulize, check valencies, set aromaticity, conjugation and hybridization\n\

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5568,6 +5568,45 @@ H      0.635000    0.635000    0.635000
           self.assertEqual(order1,order3)
           self.assertEqual(order2,order4)
     
+  def testSetBondStereoFromDirections(self):
+    m1 = Chem.MolFromMolBlock('''
+  Mrv1810 10141909482D          
+
+  4  3  0  0  0  0            999 V2000
+    3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5162   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1037   -3.7112    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.7537   -2.2823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+''', sanitize=False)
+    self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetBondType(),Chem.BondType.DOUBLE)
+    self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREONONE)
+    Chem.SetBondStereoFromDirections(m1)
+    self.assertEqual(m1.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREOTRANS)
+    
+    m2 = Chem.MolFromMolBlock('''
+  Mrv1810 10141909542D          
+
+  4  3  0  0  0  0            999 V2000
+    3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.6495   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2370   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8870   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+''',sanitize=False)
+    self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetBondType(),Chem.BondType.DOUBLE)
+    self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREONONE)
+    Chem.SetBondStereoFromDirections(m2)
+    self.assertEqual(m2.GetBondBetweenAtoms(0,1).GetStereo(),Chem.BondStereo.STEREOCIS)
+
+
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/catch_tests.cpp
+++ b/Code/GraphMol/catch_tests.cpp
@@ -543,3 +543,96 @@ M  END)CTAB";
     CHECK(outmolb.find("4  2  2  0") != std::string::npos);
   }
 }
+
+TEST_CASE(
+    "GitHub 2712: setBondStereoFromDirections() returning incorrect results"
+    "[stereochemistry]") {
+  SECTION("basics 1a") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909562D          
+
+  4  3  0  0  0  0            999 V2000
+    3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5162   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1037   -3.7112    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.7537   -2.2823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOTRANS);
+  }
+  SECTION("basics 1b") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909562D          
+
+  4  3  0  0  0  0            999 V2000
+    3.3412   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5162   -2.9968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.1037   -3.7112    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.7537   -2.2823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  4  1  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOTRANS);
+  }
+  SECTION("basics 2a") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909582D          
+
+  4  3  0  0  0  0            999 V2000
+    3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.6495   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2370   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8870   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOCIS);
+  }
+  SECTION("basics 2b") {
+    std::string mb = R"CTAB(
+  Mrv1810 10141909582D          
+
+  4  3  0  0  0  0            999 V2000
+    3.4745   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.6495   -5.2424    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2370   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8870   -5.9569    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  4  1  1  0  0  0  0
+M  END
+)CTAB";
+    bool sanitize = false;
+    std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize));
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(0)->getBondType() == Bond::DOUBLE);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREONONE);
+    MolOps::setBondStereoFromDirections(*mol);
+    CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::STEREOCIS);
+  }
+}


### PR DESCRIPTION
I discovered the bug in setBondStereoFromDirections() independently using Mol blocks, so I'm adding those tests here.

The function would also be useful in Python, so this exposes it.