### PR TITLE
Minor edits to new_CIP_labeling

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -114,10 +114,10 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
     }
   }
 
-  auto pair_cmp = [](const Node_Cfg_Pair &a, const Node_Cfg_Pair &b) {
+  auto farthest = [](const Node_Cfg_Pair &a, const Node_Cfg_Pair &b) {
     return a.first->getDistance() > b.first->getDistance();
   };
-  std::sort(aux.begin(), aux.end(), pair_cmp);
+  std::sort(aux.begin(), aux.end(), farthest);
 
   boost::unordered_map<Node *, Descriptor> queue;
   int prev = std::numeric_limits<int>::max();
@@ -178,5 +178,5 @@ void assignCIPLabels(ROMol &mol) {
   assignCIPLabels(mol, atoms, bonds);
 }
 
-} // namespace CIPLabeler
-} // end of namespace RDKit
+}  // namespace CIPLabeler
+}  // namespace RDKit

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.h
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.h
@@ -51,5 +51,5 @@ RDKIT_CIPLABELER_EXPORT void assignCIPLabels(ROMol &mol);
 RDKIT_CIPLABELER_EXPORT void
 assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
                 const boost::dynamic_bitset<> &bonds);
-}
-}
+}  // namespace CIPLabeler
+}  // namespace RDKit

--- a/Code/GraphMol/CIPLabeler/CIPMol.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPMol.cpp
@@ -37,12 +37,12 @@ CXXAtomIterator<MolGraph, Atom *> CIPMol::atoms() const {
 
 Bond *CIPMol::getBond(int idx) const { return d_mol.getBondWithIdx(idx); };
 
-CIPMolIterator<Bond *, ROMol::OEDGE_ITER> CIPMol::getBonds(Atom *atom) const {
+CIPMolSpan<Bond *, ROMol::OEDGE_ITER> CIPMol::getBonds(Atom *atom) const {
   PRECONDITION(atom, "bad atom")
   return {d_mol, d_mol.getAtomBonds(atom)};
 }
 
-CIPMolIterator<Atom *, ROMol::ADJ_ITER> CIPMol::getNeighbors(Atom *atom) const {
+CIPMolSpan<Atom *, ROMol::ADJ_ITER> CIPMol::getNeighbors(Atom *atom) const {
   PRECONDITION(atom, "bad atom")
   return {d_mol, d_mol.getAtomNeighbors(atom)};
 }

--- a/Code/GraphMol/CIPLabeler/CIPMol.h
+++ b/Code/GraphMol/CIPLabeler/CIPMol.h
@@ -21,7 +21,7 @@ namespace RDKit {
 
 namespace CIPLabeler {
 
-template <typename T, typename U> class CIPMolIterator {
+template <typename T, typename U> class CIPMolSpan {
 public:
   class CIPMolIter {
   public:
@@ -47,8 +47,8 @@ public:
   };
 
 public:
-  CIPMolIterator() = delete;
-  CIPMolIterator(ROMol &mol, std::pair<U, U> &&itr)
+  CIPMolSpan() = delete;
+  CIPMolSpan(ROMol &mol, std::pair<U, U> &&itr)
       : d_mol{mol}, d_istart{std::move(itr.first)},
         d_iend{std::move(itr.second)} {}
 
@@ -67,6 +67,8 @@ public:
 
   explicit CIPMol(ROMol &mol);
 
+  // Average atomic number with other atoms that are in an
+  // aromatic ring with this one.
   boost::rational<int> getFractionalAtomicNum(Atom *atom) const;
 
   unsigned getNumAtoms() const;
@@ -79,12 +81,14 @@ public:
 
   Bond *getBond(int idx) const;
 
-  CIPMolIterator<Bond *, ROMol::OEDGE_ITER> getBonds(Atom *atom) const;
+  CIPMolSpan<Bond *, ROMol::OEDGE_ITER> getBonds(Atom *atom) const;
 
-  CIPMolIterator<Atom *, ROMol::ADJ_ITER> getNeighbors(Atom *atom) const;
+  CIPMolSpan<Atom *, ROMol::ADJ_ITER> getNeighbors(Atom *atom) const;
 
   bool isInRing(Bond *bond) const;
 
+  // Integer bond order of a kekulized molecule
+  // Dative bonds get bond order 0.
   int getBondOrder(Bond *bond) const;
 
 private:

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -65,7 +65,7 @@ Digraph::Digraph(const CIPMol &mol, Atom *atom) : d_mol{mol} {
 
 const CIPMol &Digraph::getMol() const { return d_mol; };
 
-Node *Digraph::getOriginRoot() const { return dp_origin; };
+Node *Digraph::getOriginalRoot() const { return dp_origin; };
 
 Node *Digraph::getCurrentRoot() const { return dp_root; }
 

--- a/Code/GraphMol/CIPLabeler/Digraph.h
+++ b/Code/GraphMol/CIPLabeler/Digraph.h
@@ -1,4 +1,11 @@
 //
+// Digraph is the core data structure for determining
+// Cahn–Ingold–Prelog (CIP) chirality of a molecule.
+//
+// It's a "directed graph" - meaning that each bond
+// has a start and an end. For CIP determination,
+// the start points back towards the atom that is
+// being labelled.
 //
 //  Copyright (C) 2020 Schrödinger, LLC
 //
@@ -47,12 +54,16 @@ public:
 
   const CIPMol &getMol() const;
 
-  Node *getOriginRoot() const;
+  Node *getOriginalRoot() const;
 
   Node *getCurrentRoot() const;
 
   int getNumNodes() const;
 
+  /**
+   * Get all nodes which refer to `atom` in order of
+   * distance from the root.
+   */
   std::vector<Node *> getNodes(Atom *atom) const;
 
   /**
@@ -69,6 +80,9 @@ public:
   /**
    * Sets the root node of this digraph by flipping the directions
    * of edges as required.
+   *
+   * This is more efficient than building a new Digraph, but is
+   * only valid for neighboring Nodes.
    *
    * @param newroot the new root
    */

--- a/Code/GraphMol/CIPLabeler/Mancude.cpp
+++ b/Code/GraphMol/CIPLabeler/Mancude.cpp
@@ -202,10 +202,11 @@ std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol) {
 
         if (types[i] == Type::Cv3D3Minus || types[i] == Type::Nv2D2Minus) {
           int j = 0;
-          for (; j < numres; ++j)
+          for (; j < numres; ++j) {
             if (resparts[j] == parts[i]) {
               break;
             }
+          }
           if (j >= numres) {
             resparts[numres] = parts[i];
             ++numres;

--- a/Code/GraphMol/CIPLabeler/Node.cpp
+++ b/Code/GraphMol/CIPLabeler/Node.cpp
@@ -106,7 +106,7 @@ void Node::add(Edge *e) { d_edges.push_back(e); }
 
 void Node::setAux(Descriptor desc) { d_aux = desc; }
 
-std::vector<Edge *> Node::getEdges() const {
+const std::vector<Edge *>& Node::getEdges() const {
   if (!isExpanded()) {
     auto non_const_this = const_cast<Node *>(this);
     non_const_this->d_flags |= EXPANDED;

--- a/Code/GraphMol/CIPLabeler/Node.h
+++ b/Code/GraphMol/CIPLabeler/Node.h
@@ -97,7 +97,7 @@ public:
 
   void setAux(Descriptor desc);
 
-  std::vector<Edge *> getEdges() const;
+  const std::vector<Edge *>& getEdges() const;
 
   std::vector<Edge *> getEdges(Atom *end) const;
 

--- a/Code/GraphMol/CIPLabeler/Sort.cpp
+++ b/Code/GraphMol/CIPLabeler/Sort.cpp
@@ -24,10 +24,6 @@ const std::vector<const SequenceRule *> &Sort::getRules() const {
   return d_rules;
 }
 
-Priority Sort::prioritise(const Node *node, std::vector<Edge *> &edges) const {
-  return prioritise(node, edges, true);
-}
-
 Priority Sort::prioritise(const Node *node, std::vector<Edge *> &edges,
                           bool deep) const {
   bool unique = true;
@@ -51,12 +47,12 @@ Priority Sort::prioritise(const Node *node, std::vector<Edge *> &edges,
       }
     }
 
-  return Priority(unique, numPseudoAsym == 1);
+  return {unique, numPseudoAsym == 1};
 }
 
 int Sort::compareSubstituents(const Node *node, const Edge *a, const Edge *b,
                               bool deep) const {
-  // ensure 'up' edges are moved to the front
+  // ensure 'out' edges are moved to the front
   if (!a->isBeg(node) && b->isBeg(node)) {
     return +1;
   } else if (a->isBeg(node) && !b->isBeg(node)) {
@@ -94,4 +90,4 @@ Sort::getGroups(const std::vector<Edge *> &sorted) const {
 }
 
 } // namespace CIPLabeler
-} // namespace RDKit
+}  // namespace RDKit

--- a/Code/GraphMol/CIPLabeler/Sort.h
+++ b/Code/GraphMol/CIPLabeler/Sort.h
@@ -35,10 +35,8 @@ public:
 
   const std::vector<const SequenceRule *> &getRules() const;
 
-  Priority prioritise(const Node *node, std::vector<Edge *> &edges) const;
-
   Priority prioritise(const Node *node, std::vector<Edge *> &edges,
-                      bool deep) const;
+                      bool deep = true) const;
 
   std::vector<std::vector<Edge *>>
   getGroups(const std::vector<Edge *> &sorted) const;

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -144,7 +144,7 @@ void check_incoming_edge_count(Node *root) {
 }
 
 void expandAll(Digraph &g) {
-  auto queue = std::list<Node *>({g.getOriginRoot()});
+  auto queue = std::list<Node *>({g.getOriginalRoot()});
 
   for (const auto &node : queue) {
 
@@ -204,7 +204,7 @@ TEST_CASE("Rule1a", "[accurateCIP]") {
     auto mol = "COC"_smiles;
     CIPLabeler::CIPMol cipmol(*mol);
     Digraph g(cipmol, cipmol.getAtom(1));
-    auto origin = g.getOriginRoot();
+    auto origin = g.getOriginalRoot();
 
     auto frac = origin->getAtomicNumFraction();
     REQUIRE(frac.numerator() == 8);
@@ -225,7 +225,7 @@ TEST_CASE("Rule1a", "[accurateCIP]") {
     auto mol = "CON"_smiles;
     CIPLabeler::CIPMol cipmol(*mol);
     Digraph g(cipmol, cipmol.getAtom(1));
-    auto origin = g.getOriginRoot();
+    auto origin = g.getOriginalRoot();
 
     auto frac = origin->getAtomicNumFraction();
     REQUIRE(frac.numerator() == 8);
@@ -257,7 +257,7 @@ TEST_CASE("Rule2", "[accurateCIP]") {
     auto mol = "COC"_smiles;
     CIPLabeler::CIPMol cipmol(*mol);
     Digraph g(cipmol, cipmol.getAtom(1));
-    auto origin = g.getOriginRoot();
+    auto origin = g.getOriginalRoot();
 
     auto frac = origin->getAtomicNumFraction();
     REQUIRE(frac.numerator() == 8);
@@ -278,7 +278,7 @@ TEST_CASE("Rule2", "[accurateCIP]") {
     auto mol = "CO[13C]"_smiles;
     CIPLabeler::CIPMol cipmol(*mol);
     Digraph g(cipmol, cipmol.getAtom(1));
-    auto origin = g.getOriginRoot();
+    auto origin = g.getOriginalRoot();
 
     auto frac = origin->getAtomicNumFraction();
     REQUIRE(frac.numerator() == 8);
@@ -303,7 +303,7 @@ TEST_CASE("Rule2", "[accurateCIP]") {
     auto mol = "[13C]O[14C]"_smiles;
     CIPLabeler::CIPMol cipmol(*mol);
     Digraph g(cipmol, cipmol.getAtom(1));
-    auto origin = g.getOriginRoot();
+    auto origin = g.getOriginalRoot();
 
     auto frac = origin->getAtomicNumFraction();
     REQUIRE(frac.numerator() == 8);

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -45,7 +45,7 @@ void Sp2Bond::setPrimaryLabel(Descriptor desc) {
     return;
   }
   case Descriptor::NONE:
-    throw std::runtime_error("Received an invalid as Bond Descriptor");
+    throw std::runtime_error("Received an invalid Bond Descriptor");
   case Descriptor::R:
   case Descriptor::S:
   case Descriptor::r:
@@ -64,18 +64,18 @@ Descriptor Sp2Bond::label(const Rules &comp) {
   const auto &focus1 = getFoci()[0];
   const auto &focus2 = getFoci()[1];
 
-  auto root1 = digraph.getOriginRoot();
+  auto root1 = digraph.getOriginalRoot();
   if (digraph.getCurrentRoot() != root1) {
     digraph.changeRoot(root1);
   }
 
   const auto &root1_edges = root1->getEdges();
   const auto &internal = findInternalEdge(root1_edges, focus1, focus2);
-  auto filter = [&internal](const Edge *e) { return e != internal; };
+  auto is_internal = [&internal](const Edge *e) { return e != internal; };
 
   std::vector<Edge *> edges1;
   std::copy_if(root1_edges.begin(), root1_edges.end(),
-               std::back_inserter(edges1), filter);
+               std::back_inserter(edges1), is_internal);
 
   const auto &priority1 = comp.sort(root1, edges1);
   if (!priority1.isUnique()) {
@@ -88,7 +88,7 @@ Descriptor Sp2Bond::label(const Rules &comp) {
   std::vector<Edge *> edges2;
   const auto &root2_edges = root2->getEdges();
   std::copy_if(root2_edges.begin(), root2_edges.end(),
-               std::back_inserter(edges2), filter);
+               std::back_inserter(edges2), is_internal);
 
   const auto &priority2 = comp.sort(root2, edges2);
   if (!priority2.isUnique()) {

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
@@ -51,7 +51,7 @@ void Tetrahedral::setPrimaryLabel(Descriptor desc) {
     getFocus()->setProp(common_properties::_CIPCode, to_string(desc));
     return;
   case Descriptor::NONE:
-    throw std::runtime_error("Received an invalid as Atom Descriptor");
+    throw std::runtime_error("Received an invalid Atom Descriptor");
   case Descriptor::seqTrans:
   case Descriptor::seqCis:
   case Descriptor::E:
@@ -71,7 +71,7 @@ void Tetrahedral::setPrimaryLabel(Descriptor desc) {
 Descriptor Tetrahedral::label(const Rules &comp) {
   auto &digraph = getDigraph();
 
-  auto root = digraph.getOriginRoot();
+  auto root = digraph.getOriginalRoot();
   if (digraph.getCurrentRoot() != root) {
     digraph.changeRoot(root);
   }

--- a/Code/GraphMol/CIPLabeler/rules/Rule1a.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/Rule1a.cpp
@@ -1,5 +1,4 @@
 //
-//
 //  Copyright (C) 2020 Schrödinger, LLC
 //
 //   @@ All Rights Reserved @@
@@ -17,6 +16,7 @@ namespace CIPLabeler {
 
 Rule1a::Rule1a() = default;
 
+// CIP Rule 1a: Higher atomic number precedes lower.
 int Rule1a::compare(const Edge *a, const Edge *b) const {
   const auto afrac = a->getEnd()->getAtomicNumFraction();
   const auto bfrac = b->getEnd()->getAtomicNumFraction();

--- a/Code/GraphMol/CIPLabeler/rules/Rule1a.h
+++ b/Code/GraphMol/CIPLabeler/rules/Rule1a.h
@@ -15,6 +15,7 @@
 namespace RDKit {
 namespace CIPLabeler {
 
+// CIP Rule 1a: Higher atomic number precedes lower.
 class Rule1a : public SequenceRule {
 public:
   Rule1a();

--- a/Code/GraphMol/CIPLabeler/rules/Rules.hpp
+++ b/Code/GraphMol/CIPLabeler/rules/Rules.hpp
@@ -30,7 +30,7 @@ public:
     }
   }
 
-  ~Rules() {
+  ~Rules() override {
     for (auto &rule : d_rules) {
       delete rule;
     }


### PR DESCRIPTION
If you like, feel free to merge and squash, I don't need attribution for these changes in the final PR at RDKit.

Some edits to class and method names to match my understanding. I used "span" after `std::span`.

Also some documentation about how I understood a couple of places.

Also a minor performance tweak.